### PR TITLE
Fix bug in textarea width at contact form

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -864,6 +864,10 @@ call-to-action .button {
 	color: #fff;
 	background-color: #11ABB0;
 }
+#contact textarea {
+   min-width: 65%;
+   max-width: 65%;
+}
 #contact button.submit {
 	text-transform: uppercase;
 	letter-spacing: 3px;


### PR DESCRIPTION
The message area in the contact form lets the user changes the size of the box, but doing that breaks the entire design of the form. I added a min-width and max-width to the style of the message box, so the user can change its height but not its width.