### PR TITLE
Use page title and description from data file

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -3,12 +3,9 @@ import Head from 'next/head';
 import {useRouter} from 'next/router';
 import {memo} from 'react';
 
-interface PageProps {
-  title: string;
-  description: string;
-}
+import {HomepageMeta} from '../../data/dataDef';
 
-const Page: NextPage<PageProps> = memo(({children, title, description}) => {
+const Page: NextPage<HomepageMeta> = memo(({children, title, description}) => {
   const {asPath: pathname} = useRouter();
 
   return (

--- a/src/data/data.tsx
+++ b/src/data/data.tsx
@@ -44,14 +44,8 @@ import {
  * Page meta data
  */
 export const homePageMeta: HomepageMeta = {
-  title: 'Tim Baker',
-  description: ``,
-  ogImageUrl: ``,
-  twitterCardType: 'summary_large',
-  twitterSite: `@timbakerx`,
-  twitterCreator: `@timbakerx`,
-  twitterDomain: `reactresume.com`,
-  twitterUrl: `https://reactresume.com`,
+  title: 'React Resume Template',
+  description: "Example site built with Tim Baker's react resume template",
 };
 
 /**

--- a/src/data/dataDef.ts
+++ b/src/data/dataDef.ts
@@ -6,7 +6,7 @@ import {IconProps} from '../components/Icon/Icon';
 export interface HomepageMeta {
   title: string;
   description: string;
-  ogImageUrl: string;
+  ogImageUrl?: string;
   twitterCardType?: 'summary' | 'summary_large';
   twitterTitle?: string;
   twitterSite?: string;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,14 +9,13 @@ import Hero from '../components/Sections/Hero';
 import Portfolio from '../components/Sections/Portfolio';
 import Resume from '../components/Sections/Resume';
 import Testimonials from '../components/Sections/Testimonials';
+import {homePageMeta} from '../data/data';
 
 // eslint-disable-next-line react-memo/require-memo
 const Header = dynamic(() => import('../components/Sections/Header'), {ssr: false});
 
 const Home: FC = memo(() => {
-  const title = 'React Resume Template';
-  const description = "Example site built with Tim Baker's react resume template";
-
+  const {title, description} = homePageMeta;
   return (
     <Page description={description} title={title}>
       <Header />


### PR DESCRIPTION
Missed the page title and description when moving all data to `data.tsx`.
This moves the title and description there and populates from it

Closes #69 