### PR TITLE
change `overflow-y-scroll` to `overflow-y-auto`

### DIFF
--- a/src/components/Sections/Portfolio.tsx
+++ b/src/components/Sections/Portfolio.tsx
@@ -73,7 +73,7 @@ const ItemOverlay: FC<{item: PortfolioItem}> = memo(({item: {url, title, descrip
       ref={linkRef}
       target="_blank">
       <div className="relative h-full w-full p-4">
-        <div className="flex h-full w-full flex-col gap-y-2 overflow-y-scroll">
+        <div className="flex h-full w-full flex-col gap-y-2 overflow-y-auto">
           <h2 className="text-center font-bold text-white opacity-100">{title}</h2>
           <p className="text-xs text-white opacity-100 sm:text-sm">{description}</p>
         </div>


### PR DESCRIPTION
With `overflow-y-scroll`, a scrollbar is always visible, even if the content does not overflow the element's box. With `overflow-y-auto`, the scrollbar is only visible when the content overflows the element's box.