### PR TITLE
Fix horizontal scrolling on main page

### DIFF
--- a/src/components/Sections/Hero.tsx
+++ b/src/components/Sections/Hero.tsx
@@ -11,7 +11,7 @@ const Hero: FC = memo(() => {
   const {imageSrc, name, description, actions} = heroData;
 
   return (
-    <Section noPadding sectionId={SectionId.Hero}>
+    <Section noPadding className="overflow-x-hidden" sectionId={SectionId.Hero}>
       <div className="relative flex h-screen w-screen items-center justify-center">
         <Image
           alt={`${name}-image`}


### PR DESCRIPTION
The main page was displaying horizontal scrolling due to an overflow issue. This commit fixes the problem by adding overflow-x: hidden to the section element. This ensures that the page content fits within the viewport and eliminates the need for horizontal scrolling.