### PR TITLE
Add dynamic copyright to footer

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,1 @@
 nodeLinker: node-modules
-
-plugins:
-  - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"

--- a/src/components/Sections/Footer.tsx
+++ b/src/components/Sections/Footer.tsx
@@ -7,7 +7,6 @@ import Socials from '../Socials';
 const currentDate =new Date();
 const currentYear = currentDate.getFullYear();
 
-
 const Footer: FC = memo(() => (
   <div className="relative bg-neutral-900 px-4 pb-6 pt-12 sm:px-8 sm:pb-8 sm:pt-14">
     <div className="absolute inset-x-0 -top-4 flex justify-center sm:-top-6">

--- a/src/components/Sections/Footer.tsx
+++ b/src/components/Sections/Footer.tsx
@@ -4,8 +4,7 @@ import {FC, memo} from 'react';
 import {SectionId} from '../../data/data';
 import Socials from '../Socials';
 
-const currentDate =new Date();
-const currentYear = currentDate.getFullYear();
+const currentYear = new Date().getFullYear();
 
 const Footer: FC = memo(() => (
   <div className="relative bg-neutral-900 px-4 pb-6 pt-12 sm:px-8 sm:pb-8 sm:pt-14">

--- a/src/components/Sections/Footer.tsx
+++ b/src/components/Sections/Footer.tsx
@@ -4,6 +4,10 @@ import {FC, memo} from 'react';
 import {SectionId} from '../../data/data';
 import Socials from '../Socials';
 
+const currentDate =new Date();
+const currentYear = currentDate.getFullYear();
+
+
 const Footer: FC = memo(() => (
   <div className="relative bg-neutral-900 px-4 pb-6 pt-12 sm:px-8 sm:pb-8 sm:pt-14">
     <div className="absolute inset-x-0 -top-4 flex justify-center sm:-top-6">
@@ -26,7 +30,7 @@ const Footer: FC = memo(() => (
           <span className="italic text-yellow">Resume</span>
         </span>
       </a>
-      <span className="text-sm text-neutral-700">© Copyright 2022 Tim Baker</span>
+      <span className="text-sm text-neutral-700">© Copyright {currentYear} Tim Baker</span>
     </div>
   </div>
 ));


### PR DESCRIPTION
Fixes #123 

Update the footer's copyright section to dynamically display the current year using JavaScript's Date object. This change will ensure that the copyright information is automatically updated without any manual intervention.

modified: src/components/Sections/Footer.tsx